### PR TITLE
Add reviews and improve accessibility

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import About from './components/About';
 import Menu from './components/Menu';
 import Reservation from './components/Reservation';
 import Contact from './components/Contact';
+import Reviews from './components/Reviews';
 import Footer from './components/Footer';
 
 function App() {
@@ -16,6 +17,7 @@ function App() {
       <Menu />
       <Reservation />
       <Contact />
+      <Reviews />
       <Footer />
     </div>
   );

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -65,6 +65,7 @@ const About = () => {
               <img
                 src="https://images.pexels.com/photos/1267320/pexels-photo-1267320.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1"
                 alt="Intérieur du restaurant"
+                loading="lazy"
                 className="w-full h-80 object-cover rounded-2xl shadow-lg"
               />
               <div className="absolute inset-0 bg-gradient-to-t from-black/20 to-transparent rounded-2xl"></div>
@@ -73,11 +74,13 @@ const About = () => {
               <img
                 src="https://images.pexels.com/photos/1438672/pexels-photo-1438672.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1"
                 alt="Préparation des desserts"
+                loading="lazy"
                 className="w-full h-40 object-cover rounded-xl shadow-md"
               />
               <img
                 src="https://images.pexels.com/photos/1279330/pexels-photo-1279330.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1"
                 alt="Pâtes fraîches"
+                loading="lazy"
                 className="w-full h-40 object-cover rounded-xl shadow-md"
               />
             </div>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -49,6 +49,8 @@ const Hero = () => {
             }`}
           >
             <div
+              role="img"
+              aria-label={slide.title}
               className="h-full bg-cover bg-center"
               style={{ backgroundImage: `url(${slide.image})` }}
             >

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -52,6 +52,7 @@ const Menu = () => {
                 <img
                   src={category.image}
                   alt={category.category}
+                  loading="lazy"
                   className="w-full h-full object-cover"
                 />
                 <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent"></div>

--- a/src/components/Reservation.tsx
+++ b/src/components/Reservation.tsx
@@ -235,6 +235,7 @@ const Reservation = () => {
                 <img
                   src="https://images.pexels.com/photos/1267320/pexels-photo-1267320.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1"
                   alt="Intérieur chaleureux du restaurant"
+                  loading="lazy"
                   className="w-full h-64 object-cover"
                 />
               </div>

--- a/src/components/Reviews.tsx
+++ b/src/components/Reviews.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+const reviews = [
+  {
+    source: 'Google',
+    author: 'Marie D.',
+    text: "Une pizza délicieuse et un service chaleureux ! J'y retournerai sans hésiter."
+  },
+  {
+    source: 'TheFork',
+    author: 'Jean P.',
+    text: "Excellente adresse pour découvrir des plats italiens authentiques."
+  },
+  {
+    source: 'Google',
+    author: 'Lucie G.',
+    text: 'Ambiance conviviale et desserts à tomber !'
+  }
+];
+
+const Reviews = () => {
+  return (
+    <section className="py-20 bg-gray-50">
+      <div className="container mx-auto px-6">
+        <h2 className="text-4xl md:text-5xl font-bold text-center text-gray-800 mb-12">
+          Ils nous recommandent !
+        </h2>
+        <div className="grid md:grid-cols-3 gap-8">
+          {reviews.map((review, index) => (
+            <div key={index} className="bg-white p-6 rounded-2xl shadow-md">
+              <p className="text-gray-600 mb-4">{review.text}</p>
+              <div className="text-sm font-semibold text-gray-800">
+                {review.author} - {review.source}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default Reviews;


### PR DESCRIPTION
## Summary
- add a simple `Reviews` component with sample feedback
- display the new reviews section before the footer
- improve accessibility of the hero carousel by labeling slides
- lazy load all decorative images for faster load times

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6863e94708888331b19ab25e64a51c6a